### PR TITLE
fix make geth-up

### DIFF
--- a/makefile
+++ b/makefile
@@ -225,7 +225,7 @@ book-test:
 # This is start Ethereum in developer mode. Only when a transaction is pending will
 # Ethereum mine a block. It provides a minimal environment for development.
 geth-up:
-	geth --dev --ipcpath zarf/ethereum/geth.ipc --http.corsdomain '*' --http --allow-insecure-unlock --rpc.allow-unprotected-txs --mine --miner.threads 1 --verbosity 5 --datadir "zarf/ethereum/" --unlock 0x6327A38415C53FFb36c11db55Ea74cc9cB4976Fd --password zarf/ethereum/password
+	geth --dev --ipcpath zarf/ethereum/geth.ipc --http.corsdomain '*' --http --allow-insecure-unlock --rpc.allow-unprotected-txs --mine --verbosity 5 --datadir "zarf/ethereum/" --unlock 0x6327A38415C53FFb36c11db55Ea74cc9cB4976Fd --password zarf/ethereum/password
 
 # This will signal Ethereum to shutdown.
 geth-down:


### PR DESCRIPTION
Ethereum does not support the miner.threads flag anymore, after switching to POS. Running the command as is leads to the following error:
```
flag provided but not defined: -miner.threads
make: *** [geth-up] Error 1
```

https://github.com/ethereum/go-ethereum/pull/27178